### PR TITLE
Minor tweaks to make package fit for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /dist-newstyle/
+.stack-work/
+stack.yaml.lock
 /cabal.project.local
 /.ghc.environment.*
 *.o

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Revision history for prettyprinter-interp
 
-## 0.1.0.0 -- 2022-09-17
+## 0.1.0.0 -- 2022-10-02
 
 * First version. Released on an unsuspecting world.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Haskell package: Efficient interpolation for Prettyprinter
+[![Hackage](https://img.shields.io/hackage/v/prettyprinter-interp)](https://hackage.haskell.org/package/prettyprinter-interp)
+[![Hackage-Deps](https://img.shields.io/hackage-deps/v/prettyprinter-interp)](https://packdeps.haskellers.com/feed?needle=exact%3Aprettyprinter-interp)
+
+See [Hackage](https://hackage.haskell.org/package/prettyprinter-interp)

--- a/prettyprinter-interp.cabal
+++ b/prettyprinter-interp.cabal
@@ -4,9 +4,9 @@ version:            0.1.0.0
 synopsis:           Efficient interpolation for Prettyprinter
 description:
   This package provides efficient interpolation
-  of [@string-interpolate@](https://hackage.haskell.org/package/string-interpolate)
+  of @[string-interpolate](https://hackage.haskell.org/package/string-interpolate)@
   quasi quoters when used
-  with [@prettyprinter@](https://hackage.haskell.org/package/prettyprinter).
+  with @[prettyprinter](https://hackage.haskell.org/package/prettyprinter)@.
 homepage:           https://github.com/DigitalBrains1/prettyprinter-interp
 bug-reports:        https://github.com/DigitalBrains1/prettyprinter-interp/issues
 license:            BSD-2-Clause

--- a/release.sh
+++ b/release.sh
@@ -15,9 +15,9 @@ SDIST=$(find . -name 'prettyprinter-interp-*.tar.gz' | grep -v docs)
 DDIST=$(find . -name 'prettyprinter-interp-*.tar.gz' | grep docs)
 
 echo "To publish a release candidate, run:"
-echo "  cabal upload --username=PeterLebbing --password=\"\$(gpg -d ~/Documents/Hackage-password.gpg)\" ${SDIST}"
-echo "  cabal upload --documentation --username=PeterLebbing --password=\"\$(gpg -d ~/Documents/Hackage-password.gpg)\" ${DDIST}"
+echo "  cabal upload ${SDIST}"
+echo "  cabal upload --documentation ${DDIST}"
 echo ""
 echo "To make a release, run:"
-echo "  cabal upload --publish --username=PeterLebbing --password=\"\$(gpg -d ~/Documents/Hackage-password.gpg)\" ${SDIST}"
-echo "  cabal upload --publish --documentation --username=PeterLebbing --password=\"\$(gpg -d ~/Documents/Hackage-password.gpg)\" ${DDIST}"
+echo "  cabal upload --publish ${SDIST}"
+echo "  cabal upload --publish --documentation ${DDIST}"


### PR DESCRIPTION
Created a small README with badges for Hackage and dependencies.

Hackage package description doesn't render correctly when @ is inside hyperlink text:
  [@text@](https://somewhere)
renders incorrectly, whereas
  @[text](https://somewhere)@
renders correctly. This is a deviation from Haddock's behavior.

I put the Hackage username and password retrieval (`password-command`) inside ~/.cabal/config, no need to supply it on invocation.