### PR TITLE
CI: Test with GHC 9.2, bump versions

### DIFF
--- a/.ci/stack-8.10.7.yaml
+++ b/.ci/stack-8.10.7.yaml
@@ -1,3 +1,3 @@
-resolver: lts-18.24
+resolver: lts-18.28
 ghc-options:
   "$locals": -Wall -Wcompat -Werror

--- a/.ci/stack-9.2.4.yaml
+++ b/.ci/stack-9.2.4.yaml
@@ -1,3 +1,3 @@
-resolver: lts-19.27
+resolver: nightly-2022-10-05
 ghc-options:
   "$locals": -Wall -Wcompat -Werror

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.4"]
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -34,7 +34,7 @@ jobs:
           cp .ci/stack-${{ matrix.ghc }}.yaml stack.yaml
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.setup-haskell.outputs.stack-root }}/snapshots
           key:
@@ -57,14 +57,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.4"]
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -79,7 +79,7 @@ jobs:
           mv cabal.project.freeze frozen
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
           key:


### PR DESCRIPTION
The CI actions are bumped to the latest versions, but unfortunately
haskell/actions/setup still has an outdated Stack (2.7.5) that reports:

    Stack has not been tested with GHC versions above 9.0, and using
    9.2.4, this may fail

    Stack has not been tested with Cabal versions above 3.4, but version
    3.6.3.0 was found, this may fail

Stack LTS versions are also bumped to latest.
