### PR TITLE
Rename and deprecate `d__i'E` / `d__i'L`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for prettyprinter-interp
 
+## Unreleased
+
+* `d__i'E` and `d__i'L` are renamed to `__di'E` and `__di'L` and the existing
+  names are kept as deprecated aliases that will be removed in version 0.3. The
+  original names were a mistake that was overlooked.
+
 ## 0.1.0.0 -- 2022-10-02
 
 * First version. Released on an unsuspecting world.

--- a/prettyprinter-interp.cabal
+++ b/prettyprinter-interp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               prettyprinter-interp
-version:            0.1.0.0
+version:            0.2.0.0
 synopsis:           Efficient interpolation for Prettyprinter
 description:
   This package provides efficient interpolation
@@ -13,7 +13,7 @@ license:            BSD-2-Clause
 license-file:       LICENSE
 author:             Peter Lebbing
 maintainer:         peter@digitalbrains.com
-copyright:          (C) 2022     , Peter Lebbing
+copyright:          (C) 2022-2023, Peter Lebbing
 category:           Data, Text
 extra-source-files: CHANGELOG.md
 

--- a/src/Prettyprinter/Interpolate.hs
+++ b/src/Prettyprinter/Interpolate.hs
@@ -1,5 +1,5 @@
 {-|
-  Copyright   :  (C) 2022     , Peter Lebbing
+  Copyright   :  (C) 2022-2023, Peter Lebbing
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  Peter Lebbing <peter@digitalbrains.com>
 
@@ -66,10 +66,13 @@ module Prettyprinter.Interpolate
   ( di
   , __di
   , diii
-  , d__i'E
-  , d__i'L
+  , __di'E
+  , __di'L
   , diii'E
   , diii'L
+    -- ** Deprecated
+  , d__i'E
+  , d__i'L
   ) where
 
 #if MIN_VERSION_prettyprinter(1,7,0)
@@ -113,14 +116,14 @@ diii = wrapper 'diii iii
 -- | Wrapper around the '__i'E' quasi quoter, producing a t'Prettyprinter.Doc'
 --
 -- Newlines in the text are converted to 'Prettyprinter.line'.
-d__i'E :: QuasiQuoter
-d__i'E = wrapper 'd__i'E __i'E
+__di'E :: QuasiQuoter
+__di'E = wrapper '__di'E __i'E
 
 -- | Wrapper around the '__i'L' quasi quoter, producing a t'Prettyprinter.Doc'
 --
 -- Newlines in the text are converted to 'Prettyprinter.line'.
-d__i'L :: QuasiQuoter
-d__i'L = wrapper 'd__i'L __i'L
+__di'L :: QuasiQuoter
+__di'L = wrapper '__di'L __i'L
 
 -- | Wrapper around the 'iii'E' quasi quoter, producing a t'Prettyprinter.Doc'
 --
@@ -133,6 +136,14 @@ diii'E = wrapper 'diii'E iii'E
 -- Newlines in the text are converted to 'Prettyprinter.line'.
 diii'L :: QuasiQuoter
 diii'L = wrapper 'diii'L iii'L
+
+d__i'E :: QuasiQuoter
+d__i'E = wrapper 'd__i'E __i'E
+{-# DEPRECATED d__i'E "'d__i'E' is a deprecated alias for '__di'E' and will be removed in prettyprinter-interp 0.3" #-}
+
+d__i'L :: QuasiQuoter
+d__i'L = wrapper 'd__i'L __i'L
+{-# DEPRECATED d__i'L "'d__i'L' is a deprecated alias for '__di'L' and will be removed in prettyprinter-interp 0.3" #-}
 
 errQQ :: Name -> String -> Q a
 errQQ nm msg = fail $ show nm <> ": " <> msg


### PR DESCRIPTION
`d__i'E` and `d__i'L` are renamed to `__di'E` and `__di'L` and the existing names are kept as deprecated aliases that will be removed in version 0.3. The original names were a mistake that was overlooked.
