### PR TITLE
CI: Test with GHC 9.4, bump versions

### DIFF
--- a/.ci/stack-9.2.5.yaml
+++ b/.ci/stack-9.2.5.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2022-10-05
+resolver: lts-20.8
 ghc-options:
   "$locals": -Wall -Wcompat -Werror

--- a/.ci/stack-9.4.4.yaml
+++ b/.ci/stack-9.4.4.yaml
@@ -1,3 +1,3 @@
-resolver: lts-19.33
+resolver: nightly-2023-01-25
 ghc-options:
   "$locals": -Wall -Wcompat -Werror

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.4"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.5", "9.4.4"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.4"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.5", "9.4.4"]
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
GHC 9.2 is now 9.2.5, bumped Stack to latest versions.