### PR TITLE
Bump Stack/GHC versions

### DIFF
--- a/.ci/stack-8.6.yaml
+++ b/.ci/stack-8.6.yaml
@@ -3,4 +3,4 @@ ghc-options:
   "$locals": -Wall -Wcompat
 
 extra-deps:
-- string-interpolate-0.3.1.2@sha256:4d0987f453c66040aa8e482fe28a7d3cdc9d8df01b698bc92f42a592cfb337db,4268
+  - string-interpolate-0.3.2.1@sha256:a2fc9f9fa5b2ba254227164d2218c1665cff5fd3dae750e77163f6a9d7dcbb90,4125

--- a/.ci/stack-8.8.yaml
+++ b/.ci/stack-8.8.yaml
@@ -3,4 +3,4 @@ ghc-options:
   "$locals": -Wall -Wcompat
 
 extra-deps:
-- string-interpolate-0.3.1.2@sha256:4d0987f453c66040aa8e482fe28a7d3cdc9d8df01b698bc92f42a592cfb337db,4268
+  - string-interpolate-0.3.2.1@sha256:a2fc9f9fa5b2ba254227164d2218c1665cff5fd3dae750e77163f6a9d7dcbb90,4125

--- a/.ci/stack-9.2.yaml
+++ b/.ci/stack-9.2.yaml
@@ -1,3 +1,3 @@
-resolver: lts-20.8
+resolver: lts-20.26
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.ci/stack-9.4.yaml
+++ b/.ci/stack-9.4.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2023-01-25
+resolver: lts-21.12
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.ci/stack-9.6.yaml
+++ b/.ci/stack-9.6.yaml
@@ -1,3 +1,3 @@
-resolver: lts-21.12
+resolver: nightly-2023-09-17
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.5", "9.4.4"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.7", "9.6.2"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.5", "9.4.4", "9.6.1"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.7", "9.6.2"]
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           restore-keys: ${{ runner.os }}-stack-${{ matrix.ghc }}-
 
       - name: Install dependencies
-        run: stack build --only-dependencies
+        run: stack build --test --only-dependencies
 
       # Cache dependencies already at this point, so that we do not have to
       # rebuild them should the subsequent steps fail


### PR DESCRIPTION
Add Stack CI with GHC 9.6

The `extra-deps` for Stack CI has been changed for the versions with GHC 8.6 and 8.8. For some reason, they specified version 0.3.1.2 of `string-interpolate` even though Cabal for those GHC's picks 0.3.2.1. Changed Stack CI to use that version instead.

Additionally, the caching of Stack CI is fixed. This corrects a mistake in PR #10.

Fixes #9