### PR TITLE
Tighten lower bounds, loosen upper bounds

### DIFF
--- a/.ci/cabal.project.local-lower
+++ b/.ci/cabal.project.local-lower
@@ -1,0 +1,13 @@
+package prettyprinter-interp
+  ghc-options: -Werror
+prefer-oldest: True
+constraints:
+  any.text ==1.2.3.0,
+  any.prettyprinter ==1.2,
+  any.string-interpolate ==0.3.1.0,
+  any.tasty ==1.2.2,
+  any.tasty-hunit ==0.10.0.2,
+  -- text-conversions-0.3.1.1 misses lower bound
+  any.base64-bytestring ==1.0.0.0,
+  -- string-interpolate-0.3.1.0 misses lower bound
+  any.utf8-string ==0.3.1,

--- a/.ci/cabal.project.local-upper
+++ b/.ci/cabal.project.local-upper
@@ -1,0 +1,8 @@
+package prettyprinter-interp
+  ghc-options: -Werror
+allow-newer:
+  text,
+  tasty,
+constraints:
+  any.text == 2.1,
+  any.tasty == 1.5,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,11 +77,18 @@ jobs:
 
   # Cabal
   cabal:
-    name: Cabal / GHC ${{ matrix.ghc }}
+    name: Cabal / GHC ${{ matrix.ghc }} ${{ matrix.project-variant }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.7", "9.6.2"]
+        project-variant: [""]
+        include:
+          - ghc: 8.6.5
+            project-variant: -lower
+          - ghc: 9.6.2
+            project-variant: -upper
+
       fail-fast: false
     steps:
       - name: Checkout
@@ -97,7 +104,8 @@ jobs:
 
       - name: General Setup
         run: |
-          cp .ci/cabal.project.local .
+          cp .ci/cabal.project.local${{ matrix.project-variant}} \
+            cabal.project.local
           # Print out some information for debugging purposes
           ghc --version
           cabal --version
@@ -114,7 +122,8 @@ jobs:
         env:
           key:
             ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{
-            steps.setup-haskell.outputs.cabal-version }}
+            steps.setup-haskell.outputs.cabal-version }}${{
+            matrix.project-variant }}
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
           key:

--- a/prettyprinter-interp.cabal
+++ b/prettyprinter-interp.cabal
@@ -23,16 +23,16 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/DigitalBrains1/prettyprinter-interp
-  tag:      v0.2.0.0
+  tag:      v0.2.0.0+r2
 
 library
   exposed-modules:    Prettyprinter.Interpolate
 
   build-depends:      base                      >=4.12      && < 4.19,
                       prettyprinter             >=1.2       && < 1.8,
-                      string-interpolate        ^>=0.3.1,
+                      string-interpolate        ^>=0.3.1.0,
                       template-haskell,
-                      text                      >=1.2       && < 2.1,
+                      text                      >=1.2.3.0   && < 2.2,
   hs-source-dirs:     src
   default-language:   Haskell2010
   ghc-options:        -Wall -Wcompat
@@ -46,7 +46,7 @@ test-suite unittests
                       prettyprinter,
                       prettyprinter-interp,
                       string-interpolate,
-                      tasty                     >= 1.2      && < 1.5,
+                      tasty                     >= 1.2.2    && < 1.6,
                       tasty-hunit               ^>=0.10.0.2,
                       text,
   ghc-options:        -Wall -Wcompat


### PR DESCRIPTION
We now explicitly test in CI the lower and upper bounds in our `build-depends`.

The PvP allows incrementing just the minor version of a package in the case of an API addition. Testing the lower bounds explicitly assures we don't accidentally rely on an API addition made in a minor version.

Attempting to test this case revealed our existing lower bounds could not be tested because it did not lead to a valid build plan. So the bounds have been tightened to specify a minor version that we can actually test.

We can loosen our upper bounds to include the newest versions of `text` and `tasty` by testing this configuration with cabal's `allow-newer`.