### PR TITLE
Simplify Stack CI, switch haskell-actions

### DIFF
--- a/.ci/stack-9.4.yaml
+++ b/.ci/stack-9.4.yaml
@@ -1,3 +1,3 @@
-resolver: lts-21.12
+resolver: lts-21.14
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.ci/stack-9.6.yaml
+++ b/.ci/stack-9.6.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2023-09-17
+resolver: nightly-2023-10-09
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.7", "9.6.2"]
+        ghc: ["8.6", "8.8", "8.10", "9.0", "9.2", "9.4", "9.6"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -25,17 +25,15 @@ jobs:
           show-progress: false
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: ${{ matrix.ghc }}
           enable-stack: true
+          stack-no-global: true
 
       - name: General Setup
         run: |
-          declare GHC_VERSION=${{ matrix.ghc }}
-          # Rewrite an argument of the form X.Y.Z to X.Y
-          cp .ci/stack-${GHC_VERSION%.*}.yaml stack.yaml
+          cp .ci/stack-${{ matrix.ghc }}.yaml stack.yaml
           # Print out some information for debugging purposes
           ghc --version
           stack --version
@@ -81,12 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.7", "9.6.2"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.7", "9.6.3"]
         project-variant: [""]
         include:
           - ghc: 8.6.5
             project-variant: -lower
-          - ghc: 9.6.2
+          - ghc: 9.6.3
             project-variant: -upper
 
       fail-fast: false
@@ -97,7 +95,7 @@ jobs:
           show-progress: false
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
For Stack CI, GHC doesn't need to be installed globally; only the version installed by Stack is actually used.

The GitHub Actions for Haskell were moved to a new repository and the old one is deprecated. Switch to the new one.

Also bump all Stack/GHC versions in CI