### PR TITLE
Small CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,15 +147,15 @@ jobs:
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
       - name: Build
-        run: cabal v2-build all
+        run: cabal v2-build all --enable-tests
 
       - name: Test
-        run: cabal v2-run unittests
+        run: cabal v2-test --test-show-details=direct
 
   # Mechanism copied from https://github.com/clash-lang/clash-compiler/
   all:
     name: All jobs finished
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - cabal
       - stack


### PR DESCRIPTION
As mentioned in the GitHub Actions documentation:

> Avoid using always for any task that could suffer from a critical
> failure, for example: getting sources, otherwise the workflow may
> hang until it times out. If you want to run a job or step
> regardless of its success or failure, use the recommended
> alternative: `if: ${{ !cancelled() }}`

(Description shamelessly copied from my colleague, Martijn Bastiaan <martijn@qbaylogic.com>)