### PR TITLE
Support GHC 9.12

### DIFF
--- a/.ci/stack-9.10.yaml
+++ b/.ci/stack-9.10.yaml
@@ -1,3 +1,3 @@
-resolver: lts-22.43
+resolver: nightly-2025-03-06
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.ci/stack-9.8.yaml
+++ b/.ci/stack-9.8.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2024-05-16
+resolver: lts-23.11
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6", "8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "9.8"]
+        ghc: ["8.6", "8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "9.8", "9.10"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -79,12 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.5", "9.8.2"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.6", "9.8.4", "9.10.1"]
         project-variant: [""]
         include:
           - ghc: 8.6.5
             project-variant: -lower
-          - ghc: 9.10.1
+          - ghc: 9.12.1
             project-variant: -upper
 
       fail-fast: false

--- a/prettyprinter-interp.cabal
+++ b/prettyprinter-interp.cabal
@@ -16,6 +16,17 @@ maintainer:         peter@digitalbrains.com
 copyright:          (C) 2022-2023, Peter Lebbing
 category:           Data, Text
 extra-source-files: CHANGELOG.md
+tested-with:
+  GHC == 8.6.5,
+  GHC == 8.8.4,
+  GHC == 8.10.7,
+  GHC == 9.0.2,
+  GHC == 9.2.8,
+  GHC == 9.4.8,
+  GHC == 9.6.6,
+  GHC == 9.8.4,
+  GHC == 9.10.1,
+  GHC == 9.12.1
 
 source-repository head
   type:     git
@@ -23,12 +34,12 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/DigitalBrains1/prettyprinter-interp
-  tag:      v0.2.0.0+r4
+  tag:      v0.2.0.0+r5
 
 library
   exposed-modules:    Prettyprinter.Interpolate
 
-  build-depends:      base                      >=4.12      && < 4.21,
+  build-depends:      base                      >=4.12      && < 4.23,
                       prettyprinter             >=1.2       && < 1.8,
                       string-interpolate        ^>=0.3.1.0,
                       template-haskell,


### PR DESCRIPTION
And bump all CI tests to the latest minor versions