### PR TITLE
Allow manually triggering CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This makes it possible to prime the caches on the main branch when they had expired, speeding up PR's and merges.