### PR TITLE
 Add GHC 9.14 to CI

### DIFF
--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -1,2 +1,3 @@
 package prettyprinter-interp
   ghc-options: -Werror
+  tests: True

--- a/.ci/cabal.project.local-lower
+++ b/.ci/cabal.project.local-lower
@@ -1,6 +1,9 @@
 package prettyprinter-interp
   ghc-options: -Werror
+  tests: True
+
 prefer-oldest: True
+
 constraints:
   any.text ==1.2.3.0,
   any.prettyprinter ==1.2,

--- a/.ci/cabal.project.local-upper
+++ b/.ci/cabal.project.local-upper
@@ -1,5 +1,6 @@
 package prettyprinter-interp
   ghc-options: -Werror
+  tests: True
 
 repository head.hackage.ghc.haskell.org
    url: https://ghc.gitlab.haskell.org/head.hackage/

--- a/.ci/stack-9.12.yaml
+++ b/.ci/stack-9.12.yaml
@@ -1,3 +1,3 @@
-resolver: lts-24.27
+resolver: nightly-2026-01-10
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.ci/stack-9.6.yaml
+++ b/.ci/stack-9.6.yaml
@@ -1,3 +1,3 @@
-resolver: lts-22.43
+resolver: lts-22.44
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.ci/stack-9.8.yaml
+++ b/.ci/stack-9.8.yaml
@@ -1,3 +1,3 @@
-resolver: lts-23.11
+resolver: lts-23.28
 ghc-options:
   "$locals": -Wall -Wcompat

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
         # to GHC. Options specified in stack.yaml (like -Wcompat) are still
         # passed; it is cumulative. Future versions of Stack might add behavior
         # to --pedantic.
-        run : stack build --pedantic
+        run : stack build --test --no-run-tests --pedantic
 
       - name: Test
         run : stack test
@@ -116,7 +116,7 @@ jobs:
         # dependencies, for cache invalidation.
         run: |
           cabal v2-update
-          cabal v2-build all --enable-tests --dry-run
+          cabal v2-build all --dry-run
 
       - name: Restore cached dependencies
         uses: actions/cache/restore@v3
@@ -134,7 +134,7 @@ jobs:
           restore-keys: ${{ env.key }}-
 
       - name: Install dependencies
-        run: cabal v2-build all --enable-tests --only-dependencies
+        run: cabal v2-build all --only-dependencies
 
       # Cache dependencies already at this point, so that we do not have to
       # rebuild them should the subsequent steps fail
@@ -148,7 +148,7 @@ jobs:
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
       - name: Build
-        run: cabal v2-build all --enable-tests
+        run: cabal v2-build all
 
       - name: Test
         run: cabal v2-test --test-show-details=direct

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6", "8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "9.8", "9.10"]
+        ghc: ["8.6", "8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "9.8", "9.10", "9.12"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -80,12 +80,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.6", "9.8.4", "9.10.1"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.7", "9.8.4",
+              "9.10.3", "9.12.2"]
         project-variant: [""]
         include:
           - ghc: 8.6.5
             project-variant: -lower
-          - ghc: 9.12.1
+          - ghc: 9.14.1
             project-variant: -upper
 
       fail-fast: false

--- a/prettyprinter-interp.cabal
+++ b/prettyprinter-interp.cabal
@@ -23,10 +23,11 @@ tested-with:
   GHC == 9.0.2,
   GHC == 9.2.8,
   GHC == 9.4.8,
-  GHC == 9.6.6,
+  GHC == 9.6.7,
   GHC == 9.8.4,
-  GHC == 9.10.1,
-  GHC == 9.12.1
+  GHC == 9.10.3,
+  GHC == 9.12.2,
+  GHC == 9.14.1
 
 source-repository head
   type:     git

--- a/release.sh
+++ b/release.sh
@@ -6,6 +6,7 @@ rm -rf dist-newstyle
 rm -rf .ghc.env*
 
 cabal sdist
+cabal v2-build prettyprinter-interp --only-dependencies
 cabal v2-haddock prettyprinter-interp \
   --haddock-for-hackage \
   --haddock-hyperlinked-source \


### PR DESCRIPTION
PR #17 accidentally relaxed the upper bound on `base` to already cover GHC 9.14. Let's verify that it actually works, shall we?

Bumped all the versions tested in CI to the latest.

Tweak some details on CI and `release.sh`.